### PR TITLE
Add localized CV download button

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -1,0 +1,19 @@
+.avatar {
+    height: auto;
+    overflow: visible;
+    padding-top: 16rem;
+}
+
+.cv-download {
+    text-align: center;
+    margin-top: 1rem;
+
+    &__button {
+        display: inline-block;
+        padding: 0.5rem 1rem;
+        background-color: $color-primary;
+        color: $color-icon-primary;
+        text-decoration: none;
+        border-radius: 0.25rem;
+    }
+}

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -1,0 +1,2 @@
+[downloadCV]
+other = "Lebenslauf herunterladen"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,0 +1,2 @@
+[downloadCV]
+other = "Download CV"

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -1,0 +1,2 @@
+[downloadCV]
+other = "Descargar CV"

--- a/layouts/partials/_avatar.html
+++ b/layouts/partials/_avatar.html
@@ -1,0 +1,12 @@
+{{ if .BasicInfo.Photo }}
+    <div class="sideSection avatar">
+        <div class="avatar__container">
+            <img class="avatar__img" src="{{ .BasicInfo.Photo }}" alt="photo of me">
+        </div>
+        <div class="cv-download">
+            <a class="cv-download__button" href="https://www.dropbox.com/scl/fi/v4n4hy1c09nd41bqsfbze/Nicolas-Robayo-Pardo-cv.pdf?rlkey=m0xrcterycabecam8v3fwkun6&st=y73kpcoc&dl=0" target="_blank" rel="noopener">
+                {{ i18n "downloadCV" }}
+            </a>
+        </div>
+    </div>
+{{ end }}


### PR DESCRIPTION
## Summary
- add CV download button below profile image
- style button and add i18n strings
- adjust avatar styling so the button sits beneath the image with adequate spacing

## Testing
- `hugo --minify`


------
https://chatgpt.com/codex/tasks/task_e_688e24dee94c8321afc150784a99c07f